### PR TITLE
bugfix, guests don't upload their guesses anymore

### DIFF
--- a/app/src/main/java/com/github/wnder/GuessLocationActivity.java
+++ b/app/src/main/java/com/github/wnder/GuessLocationActivity.java
@@ -28,6 +28,7 @@ import com.github.wnder.picture.Picture;
 import com.github.wnder.picture.PicturesDatabase;
 import com.github.wnder.scoreboard.ScoreboardActivity;
 import com.github.wnder.user.GlobalUser;
+import com.github.wnder.user.GuestUser;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -422,7 +423,7 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
             confirmButtonView.setForeground(getDrawable(R.drawable.ic_baseline_military_tech_24));
 
             //Send guess and update karma
-            if(!pictureID.equals(Picture.UNINITIALIZED_ID)){
+            if(!pictureID.equals(Picture.UNINITIALIZED_ID) && !(GlobalUser.getUser() instanceof GuestUser)){
                 Location guessedLocation = new Location("");
                 guessedLocation.setLatitude(guessPosition.getLatitude());
                 guessedLocation.setLongitude(guessPosition.getLongitude());

--- a/app/src/main/java/com/github/wnder/GuessLocationActivity.java
+++ b/app/src/main/java/com/github/wnder/GuessLocationActivity.java
@@ -428,8 +428,8 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
                 guessedLocation.setLatitude(guessPosition.getLatitude());
                 guessedLocation.setLongitude(guessPosition.getLongitude());
                 picturesDb.sendUserGuess(pictureID, GlobalUser.getUser().getName(), guessedLocation);
-                picturesDb.updateKarma(pictureID, 1);
             }
+            picturesDb.updateKarma(pictureID, 1);
 
             showActualLocation();
         } else {

--- a/app/src/main/java/com/github/wnder/GuessLocationActivity.java
+++ b/app/src/main/java/com/github/wnder/GuessLocationActivity.java
@@ -23,12 +23,14 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
 import com.github.wnder.picture.Picture;
 import com.github.wnder.picture.PicturesDatabase;
 import com.github.wnder.scoreboard.ScoreboardActivity;
 import com.github.wnder.user.GlobalUser;
 import com.github.wnder.user.GuestUser;
+import com.github.wnder.user.User;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -95,6 +97,9 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
     private SensorEventListener listener;
 
     private String pictureID = Picture.UNINITIALIZED_ID;
+
+    private User user;
+    private Context context;
 
     @Inject
     public PicturesDatabase picturesDb;
@@ -188,6 +193,9 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
         Mapbox.getInstance(this, getString(R.string.mapbox_access_token));
         setContentView(R.layout.activity_guess_location);
 
+        user = GlobalUser.getUser();
+        context = this;
+
         mapView = findViewById(R.id.mapView);
         mapView.onCreate(savedInstanceState);
         mapView.getMapAsync(this);
@@ -202,7 +210,7 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
             @Override
             public void run() {
                 handler.post(() -> {
-                    Location loc = GlobalUser.getUser().getPositionFromGPS((LocationManager) getSystemService(Context.LOCATION_SERVICE), GuessLocationActivity.this);
+                    Location loc = user.getPositionFromGPS((LocationManager) getSystemService(Context.LOCATION_SERVICE), GuessLocationActivity.this);
                     if (compassMode) {
                         LatLng destinationPoint = new LatLng(loc.getLatitude(), loc.getLongitude());
                         updatePositionByLineAnimation(guessSource, guessAnimator, guessPosition, destinationPoint);
@@ -212,6 +220,8 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
             }
         };
         timer = new Timer(true);
+
+
     }
 
     /**
@@ -225,7 +235,7 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
         //Set camera position
         CameraPosition position = new CameraPosition.Builder()
                 .target(cameraPosition)
-                .zoom(zoomFromKilometers(cameraPosition, GlobalUser.getUser().getRadius()))
+                .zoom(zoomFromKilometers(cameraPosition, user.getRadius()))
                 .build();
         this.mapboxMap.setCameraPosition(position);
 
@@ -334,7 +344,7 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
         SymbolLayer layer = (SymbolLayer) mapboxMap.getStyle().getLayer(String.valueOf(R.string.ORANGE_ARROW_LAYER_ID));
         View hotbarView = findViewById(R.id.hotbarView);
         //Arbitrary value based on the radius to check if we are close enough
-        double referenceDistance = GlobalUser.getUser().getRadius() * 1000 / 100;
+        double referenceDistance = user.getRadius() * 1000 / 100;
 
         if (!compassMode) {
             layer.setProperties(PropertyFactory.visibility(Property.NONE));
@@ -379,7 +389,7 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
             sensorManager.registerListener(listener, (Sensor) list.get(0), SensorManager.SENSOR_DELAY_NORMAL);
             updateGuessPositionFromGPS.run();
             mapboxMap.getUiSettings().setRotateGesturesEnabled(false);
-            compassModeButtonView.setForeground(getDrawable(R.drawable.ic_outline_explore_24));
+            compassModeButtonView.setForeground(ContextCompat.getDrawable(context, R.drawable.ic_outline_explore_24));
         }
     }
 
@@ -401,7 +411,7 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
             updateCompassMode();
             sensorManager.unregisterListener(listener);
             mapboxMap.getUiSettings().setRotateGesturesEnabled(true);
-            compassModeButtonView.setForeground(getDrawable(R.drawable.ic_outline_explore_off_24));
+            compassModeButtonView.setForeground(ContextCompat.getDrawable(context, R.drawable.ic_outline_explore_off_24));
         }
     }
 
@@ -420,14 +430,14 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
 
             findViewById(R.id.compassMode).setVisibility(View.INVISIBLE);
             View confirmButtonView = findViewById(R.id.confirmButton);
-            confirmButtonView.setForeground(getDrawable(R.drawable.ic_baseline_military_tech_24));
+            confirmButtonView.setForeground(ContextCompat.getDrawable(context, R.drawable.ic_baseline_military_tech_24));
 
             //Send guess and update karma
-            if(!pictureID.equals(Picture.UNINITIALIZED_ID) && !(GlobalUser.getUser() instanceof GuestUser)){
+            if(!pictureID.equals(Picture.UNINITIALIZED_ID) && !(user instanceof GuestUser)){
                 Location guessedLocation = new Location("");
                 guessedLocation.setLatitude(guessPosition.getLatitude());
                 guessedLocation.setLongitude(guessPosition.getLongitude());
-                picturesDb.sendUserGuess(pictureID, GlobalUser.getUser().getName(), guessedLocation);
+                picturesDb.sendUserGuess(pictureID, user.getName(), guessedLocation);
             }
             picturesDb.updateKarma(pictureID, 1);
 
@@ -467,7 +477,7 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
             dText = getString(R.string.distance_kilometer,(int)distanceFromPicture/1000);
         }
 
-        double score = Score.calculationScore(distanceFromPicture, GlobalUser.getUser().getRadius() * 1000);
+        double score = Score.calculationScore(distanceFromPicture, user.getRadius() * 1000);
         TextView scoreText = findViewById(R.id.scoreText);
         scoreText.setText(getString(R.string.score, (int)score) + "\n" + dText);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,10 +53,6 @@
     <!--Guess Location Strings-->
     <string name="content_descr_compass_button_image">This is the image shown on the compass button</string>
     <string name="content_descr_confirm_button_image">This is the image shown on the confirm button</string>
-    <string name="content_descr_guess_hotbar_image">This is the image of the hotbar shown in Compass Mode when close to the picture</string>
-    <string name="switchCompassModeText">Exit Compass Mode</string>
-    <string name="switchNormalModeText">Compass Mode</string>
-    <string name="confirmButtonPressedOnce">See Scoreboard</string>
     <string name="mapClickOnCompassMode_confirm_title">You are in Compass Mode</string>
     <string name="mapClickOnCompassMode_confirm_message">In Compass Mode you are supposed to walk to the picture location you are currently guessing.\nExit the Compass Mode if you want to simply guess by clicking</string>
     <string name="distance_meter">Distance: %1$dm</string>
@@ -76,7 +72,6 @@
     <string name="content_descr_history_display_picture">Previously guessed picture</string>
 
     <!--Scoreboard strings-->
-    <string name="leave_scoreboard">Leave Scoreboard</string>
     <string name="scoreboard_username_placeholder">Username</string>
     <string name="scoreboard_score_placeholder">Score</string>
     <string name="scoreboard_rank_placeholder">1</string>


### PR DESCRIPTION
Guests won't send their scores and guesses on the db anymore
Design choice to do before approving: with this bugfix, a guest guessing a picture does adds a point to the picture's karma, do we want it that way or do we want a guest's guess not to update the karma ? Same question for when skipping ?
Briefly: do we want guests to have an impact on picture's karmas ?