### PR TITLE
corrected a reoccuring crash when leaving guess location

### DIFF
--- a/app/src/main/java/com/github/wnder/GuessLocationActivity.java
+++ b/app/src/main/java/com/github/wnder/GuessLocationActivity.java
@@ -606,6 +606,8 @@ public class GuessLocationActivity extends AppCompatActivity implements OnMapRea
      */
     @Override
     protected void onDestroy() {
+        //unregister listener!
+        sensorManager.unregisterListener(listener);
         super.onDestroy();
         mapView.onDestroy();
     }


### PR DESCRIPTION
When we were leaving guess location activity with compass mode enabled, the app crashed.
That's because a listener depending on the map was never unregistered when doing this, whereas the map was destroyed.