### PR TITLE
BUGFIX: can't guess "no photos available" anymore

### DIFF
--- a/app/src/androidTest/java/com/github/wnder/TourDatabaseTest.java
+++ b/app/src/androidTest/java/com/github/wnder/TourDatabaseTest.java
@@ -96,7 +96,7 @@ public class TourDatabaseTest {
 
     // Clean db
     @AfterClass
-    public static void deleteTestTour() {
+    public static void deleteTestTour(){
         FirebaseFirestore.getInstance().collection("pictures").document(firstUniqueId)
                 .collection("userData").document("userGuesses").delete();
         FirebaseFirestore.getInstance().collection("pictures").document(firstUniqueId)

--- a/app/src/main/java/com/github/wnder/guessLocation/GuessPreviewActivity.java
+++ b/app/src/main/java/com/github/wnder/guessLocation/GuessPreviewActivity.java
@@ -77,6 +77,7 @@ public class GuessPreviewActivity extends AppCompatActivity{
 
         //Setup buttons
         findViewById(R.id.guessButton).setOnClickListener(id -> openGuessActivity());
+        findViewById(R.id.guessButton).setVisibility(View.INVISIBLE);
 
         //Setup swipe
         imageDisplayed.setOnClickListener(id -> {});
@@ -137,6 +138,7 @@ public class GuessPreviewActivity extends AppCompatActivity{
                     pictureLng = Lct.getLongitude();
                 });
                 pictureID = picId;
+                findViewById(R.id.guessButton).setVisibility((View.VISIBLE));
             } else {
                 //If not, display default picture
                 // Maybe create a bitmap that tells that no pictures were available (this one is just the one available)


### PR DESCRIPTION
Guessing  inexistant photos (and making the app crash) is now no longer possible. (Guess button will only show if the picture is legit and guessable)